### PR TITLE
Direct Deploy to Salesforce failing for ToolingAPITest.cls

### DIFF
--- a/src/package.xml
+++ b/src/package.xml
@@ -3,6 +3,7 @@
     <types>
         <members>ToolingAPI</members>
         <members>ToolingAPIDemo</members>
+        <members>ToolingAPITest</members>
         <name>ApexClass</name>
     </types>
     <version>29.0</version>


### PR DESCRIPTION
On direct deployment/installation to salesforce, receiving one of error.ToolingAPITest.cls deployment is failing, rest all components get succesfully deployed. Please refer below log.  
Deployment Started
Status: Queued 
Status: InProgress 
....
Status: Completed 
Deployment Complete
Failures:
classes/ToolingAPITest.cls(ToolingAPITest):Not in package.xml
