### PR TITLE
Updated line no 1648 and 1651 to address JSON parser issue

### DIFF
--- a/src/classes/ToolingAPI.cls
+++ b/src/classes/ToolingAPI.cls
@@ -1645,10 +1645,10 @@ public with sharing class ToolingAPI {
     }
 
     public class WorkflowTimeTrigger {
-        public WorkflowActionReference actions;
+        public WorkflowActionReference[] actions;
         public String offsetFromField;
         public String timeLength;
-        public String workflowTimeTrigger;
+        public String workflowTimeTriggerUnit;
     }
 
     public class WorkflowFieldUpdateMetadata extends WorkflowAction {


### PR DESCRIPTION
Updated line no 1648 to declare properly. 
- Changed from public WorkflowActionReference actions; to public WorkflowActionReference[] actions; (array [] sign was missing). 
- This fixed JSON parser issue that I reported.

Updated line no 1651 to use proper variable name so that JSON parser is able to assign value to same.
- Changed from public String workflowTimeTrigger; to public String workflowTimeTriggerUnit;
- This fixed issue that workflowTimeTrigger variable was always coming null.
