### PR TITLE
remove remove call

### DIFF
--- a/src/classes/ToolingAPI.cls
+++ b/src/classes/ToolingAPI.cls
@@ -173,7 +173,6 @@ public class ToolingAPI {
         List<ToolingAPIWSDL.sObject_x> records = (List<ToolingAPIWSDL.sobject_x>)Type.forName('List<'+recordClassName+'>').newInstance();
         for(Integer i=0; i < sobjArr.size(); i++){
             records.add(castSobjToSubclass(sObjArr.get(i),recordClassName));
-            sObjArr.remove(i);
         }
         return records;
     }


### PR DESCRIPTION
This remove call causes every other record to be output when querying. See https://gist.github.com/frontendloader/749c19bd45d5515d1337
If for some reason this is necessary, will need to iterate in reverse.